### PR TITLE
Function reference for echoing a panel variable.

### DIFF
--- a/template-tags.php
+++ b/template-tags.php
@@ -4,6 +4,10 @@ function get_panel_var( $name ) {
 	return \ModularContent\Plugin::instance()->loop()->get_var( $name );
 }
 
+function panel_var( $name ) {
+	echo get_panel_var( $name );
+}
+
 function get_panel_vars() {
  return \ModularContent\Plugin::instance()->loop()->vars();
 }


### PR DESCRIPTION
In lieu of always having to write extra code to echo simple panel variables (e.g titles, content), this additional function allows for easily echoing those variables.

If we need to rename the function, that's cool.
