### PR TITLE
preserve numeric array keys in option values

### DIFF
--- a/ModularContent/Fields/Field.php
+++ b/ModularContent/Fields/Field.php
@@ -58,6 +58,7 @@ abstract class Field {
 		// merge defaults with passed args
 		foreach ( $this->defaults as $key => $value ) {
 			if ( is_array( $value ) && isset( $args[ $key ] ) ) {
+				// use union operator (+) instead of array_merge() to preserve numeric keys
 				$args[ $key ] = $args[ $key ] + $value;
 			}
 		}


### PR DESCRIPTION
If a select/radio has numeric keys for its options, those keys are
reset to sequential integers when the panel type is instantiated.
This is because the values pass through, `wp_parse_args()`, which in
turn relies on `array_merge()`. Switching to a union (`+`) operator to
merge arrays will preserve those numeric keys.
