### PR TITLE
check preview_id query var rather than is_preview to trigger autosave preview

### DIFF
--- a/ModularContent/Plugin.php
+++ b/ModularContent/Plugin.php
@@ -48,7 +48,7 @@ class Plugin {
 
 			if ( $current_post && isset($current_post->post_type) && post_type_supports( $current_post->post_type, 'modular-content' ) ) {
 
-				if ( is_preview() ) {
+				if ( !empty( $_GET['preview_id'] ) ) {
 					$autosave = wp_get_post_autosave( get_the_ID() );
 					if ( $autosave ) {
 						$current_post = $autosave;


### PR DESCRIPTION
Any time you view a draft post, is_preview() is true. There
may or may not be a more recent autosave, but the user will
only want to view the autosave when clicking the 'Preview'
button (to view unsaved changes). At all other times,
the draft post should be displayed.

From https://github.com/HarvardLawSchool/panel-builder/pull/2
