### PR TITLE
Add ability to restrict by post type

### DIFF
--- a/ModularContent/Blueprint_Builder.php
+++ b/ModularContent/Blueprint_Builder.php
@@ -87,11 +87,24 @@ class Blueprint_Builder implements \JsonSerializable {
 	}
 
 	public function jsonSerialize() {
-		$blueprint = $this->get_blueprint();
+		$type = $this->get_current_post_type();
+		$blueprint = $this->get_blueprint( $type );
 		foreach ( $blueprint[ 'types' ] as $index => $panel ) {
 			$blueprint[ 'types' ][ $index ] = $this->normalize_string_arrays( $panel );
 		}
 		return $blueprint;
+	}
+
+	private function get_current_post_type() {
+		$type = null;
+		if ( ! is_admin() ) {
+			return $type;
+		}
+		global $pagenow;
+		if ( ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
+			return $type;
+	  	}
+		return get_post_type( get_queried_object_id() );
 	}
 
 	private function normalize_string_arrays( $blueprint ) {


### PR DESCRIPTION
This is a relatively straightforward edit - by adding in the current Post Type for the `get_blueprint()` call, any panel can be restricted to a specific set of Post Types simply by setting the `$post_types` protected property in the class. 

I added in a check to make sure we only add the post type on post edit/add screens to ensure that it doesn't muck around with anything else. 
