### PR TITLE
save empty values for all fields - #67595

### DIFF
--- a/ModularContent/Fields/Group.php
+++ b/ModularContent/Fields/Group.php
@@ -172,4 +172,21 @@ class Group extends Field {
 		}
 		return $blueprint;
 	}
+
+	/**
+	 * Ensure that the submitted array is keyless
+	 *
+	 * @param array $data
+	 * @return array
+	 */
+	public function prepare_data_for_save( $data ) {
+		foreach ( $this->fields as $field ) {
+			$name = $field->get_name();
+			if ( ! isset( $data[ $name ] ) ) {
+				$data[ $name ] = null;
+			}
+			$data[ $name ] = $field->prepare_data_for_save( $data[ $name ] );
+		}
+		return $data;
+	}
 } 

--- a/ModularContent/Fields/Hidden.php
+++ b/ModularContent/Fields/Hidden.php
@@ -28,4 +28,14 @@ class Hidden extends Field {
 	public function render_description() {
 		// no description for hidden fields
 	}
+
+	/**
+	 * Massage submitted data before it's saved.
+	 *
+	 * @param mixed $data
+	 * @return string
+	 */
+	public function prepare_data_for_save( $data ) {
+		return (string) $data;
+	}
 } 

--- a/ModularContent/Fields/Image.php
+++ b/ModularContent/Fields/Image.php
@@ -156,4 +156,14 @@ class Image extends Field {
 			$cache->add_image( $data );
 		}
 	}
+
+	/**
+	 * Massage submitted data before it's saved.
+	 *
+	 * @param mixed $data
+	 * @return int
+	 */
+	public function prepare_data_for_save( $data ) {
+		return (int) $data;
+	}
 }

--- a/ModularContent/Fields/ImageGallery.php
+++ b/ModularContent/Fields/ImageGallery.php
@@ -81,4 +81,15 @@ class ImageGallery extends Field {
 			}
 		}
 	}
+
+	/**
+	 * Massage submitted data before it's saved.
+	 *
+	 * @param mixed $data
+	 * @return int[]
+	 */
+	public function prepare_data_for_save( $data ) {
+		$data = (array) $data;
+		return array_map( 'intval', $data );
+	}
 }

--- a/ModularContent/Fields/Link.php
+++ b/ModularContent/Fields/Link.php
@@ -65,4 +65,14 @@ class Link extends Field {
 		return $this->default;
 	}
 
+
+	/**
+	 * Massage submitted data before it's saved.
+	 *
+	 * @param mixed $data
+	 * @return array
+	 */
+	public function prepare_data_for_save( $data ) {
+		return wp_parse_args( $data, [ 'url' => '', 'target' => '', 'label' => '' ] );
+	}
 } 

--- a/ModularContent/Fields/PostQuacker.php
+++ b/ModularContent/Fields/PostQuacker.php
@@ -249,4 +249,26 @@ class PostQuacker extends Field {
 			}
 		}
 	}
+
+	/**
+	 * Massage submitted data for consistency
+	 *
+	 * @param array $data
+	 * @return array
+	 */
+	public function prepare_data_for_save( $data ) {
+		$data = wp_parse_args( $data, [
+			'post_id' => 0,
+			'title'   => '',
+			'content' => '',
+			'image'   => 0,
+			'link'    => [
+				'url'    => '',
+				'target' => '',
+				'label'  => '',
+			],
+		]);
+
+		return $data;
+	}
 }

--- a/ModularContent/Fields/Post_List.php
+++ b/ModularContent/Fields/Post_List.php
@@ -295,15 +295,36 @@ class Post_List extends Field {
 	}
 
 	/**
-	 * Ensure that the submitted array is keyless
+	 * Massage submitted data for consistency
 	 *
 	 * @param array $data
 	 * @return array
 	 */
 	public function prepare_data_for_save( $data ) {
-		if ( array_key_exists( 'posts', $data ) && is_array( $data[ 'posts' ] ) ) {
-			$data[ 'posts' ] = array_values( $data[ 'posts' ] );
+		$data = wp_parse_args( $data, [ 'type' => 'manual', 'posts' => [], 'filters' => [], 'max' => 0 ] );
+
+		foreach ( $data[ 'posts' ] as &$post_data ) {
+			switch( $post_data[ 'method' ] ) {
+				case 'select':
+					if ( empty( $post_data[ 'id' ] ) ) {
+						$post_data = null;
+					}
+					break;
+				case 'manual':
+					$post_data = wp_parse_args( $post_data, [
+						'post_title'   => '',
+						'post_content' => '',
+						'thumbnail_id' => 0,
+						'url'          => '',
+					] );
+					break;
+				default:
+					$post_data = null;
+					break;
+			}
 		}
+
+		$data[ 'posts' ] = array_values( array_filter( $data[ 'posts' ] ) ); // values to avoid non-sequential keys
 
 		return $data;
 	}

--- a/ModularContent/Fields/Repeater.php
+++ b/ModularContent/Fields/Repeater.php
@@ -195,8 +195,18 @@ class Repeater extends Group {
 	 * @return array
 	 */
 	public function prepare_data_for_save( $data ) {
-		if ( is_array( $data ) ) {
-			return array_values( $data );
+		if ( ! is_array( $data ) ) {
+			$data = [];
+		}
+		$data = array_values( $data ); // ensure sequential numeric keys
+		foreach ( $data as &$instance ) {
+			foreach ( $this->fields as $field ) {
+				$name = $field->get_name();
+				if ( ! isset( $instance[ $name ] ) ) {
+					$instance[ $name ] = null;
+				}
+				$instance[ $name ] = $field->prepare_data_for_save( $instance[ $name ] );
+			}
 		}
 		return $data;
 	}

--- a/ModularContent/Fields/Select.php
+++ b/ModularContent/Fields/Select.php
@@ -75,4 +75,14 @@ class Select extends Field {
 		}
 		return $blueprint;
 	}
+
+	/**
+	 * Massage submitted data before it's saved.
+	 *
+	 * @param mixed $data
+	 * @return string
+	 */
+	public function prepare_data_for_save( $data ) {
+		return (string) $data;
+	}
 } 

--- a/ModularContent/Fields/Text.php
+++ b/ModularContent/Fields/Text.php
@@ -21,4 +21,14 @@ class Text extends Field {
 	public function render_field() {
 		printf('<span class="panel-input-field"><input type="text" name="%s" value="%s" size="40" /></span>', $this->get_input_name(), $this->get_input_value());
 	}
+
+	/**
+	 * Massage submitted data before it's saved.
+	 *
+	 * @param mixed $data
+	 * @return string
+	 */
+	public function prepare_data_for_save( $data ) {
+		return (string) $data;
+	}
 }

--- a/ModularContent/Fields/TextArea.php
+++ b/ModularContent/Fields/TextArea.php
@@ -142,4 +142,14 @@ class TextArea extends Field {
 
 		return $editor_id;
 	}
+
+	/**
+	 * Massage submitted data before it's saved.
+	 *
+	 * @param mixed $data
+	 * @return string
+	 */
+	public function prepare_data_for_save( $data ) {
+		return (string) $data;
+	}
 }

--- a/ModularContent/Panel.php
+++ b/ModularContent/Panel.php
@@ -215,9 +215,10 @@ class Panel implements \JsonSerializable {
 		$output = $this->data;
 		foreach ( $this->type->all_fields() as $field ) {
 			$name = $field->get_name();
-			if ( isset( $this->data[$name] ) ) {
-				$output[$name] = $field->prepare_data_for_save( $this->data[$name] );
+			if ( ! isset( $this->data[ $name ] ) ) {
+				$this->data[ $name ] = null;
 			}
+			$output[ $name ] = $field->prepare_data_for_save( $this->data[ $name ] );
 		}
 		return $output;
 	}


### PR DESCRIPTION
https://central.tri.be/issues/67595

When the user doesn't set a value for a field in the UI, the
react app doesn't event submit the field. This results in a lot
of missing keys in the database, and usually results int
notices in the templates.

This updates the saving process to make sure that all fields
have a sensible empty value set when the panel is saved with
no value submitted for that field.

I'm doing this on save rather than on render for two reasons:

1. It can be a somewhat expensive process.
2. The Post_List field especially seems somewhat brittle when working with partial data, so I want to make sure this handles both the front-end render and the admin.