### PR TITLE
Add fix to allow all panel types to appear for Panel Sets

### DIFF
--- a/ModularContent/Blueprint_Builder.php
+++ b/ModularContent/Blueprint_Builder.php
@@ -4,6 +4,8 @@
 namespace ModularContent;
 
 
+use ModularContent\Sets\Set;
+
 class Blueprint_Builder implements \JsonSerializable {
 	/** @var TypeRegistry */
 	private $registry;
@@ -104,7 +106,13 @@ class Blueprint_Builder implements \JsonSerializable {
 		if ( ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
 			return $type;
 	  	}
-		return get_post_type( get_queried_object_id() );
+		$type = get_post_type( get_queried_object_id() );
+
+		// Return null so all panel types are available to Panel Sets.
+		if ( Set::POST_TYPE === $type ) {
+			return null;
+		}
+		return $type;
 	}
 
 	private function normalize_string_arrays( $blueprint ) {


### PR DESCRIPTION
I believe this is a by-product of adding in Post Type restrictions to Panels - essentially unless we specifically add the `Set` post type to the list of types for a given Panel, that panel isn't made available to the Panel Sets post type/UI. This fix detects that post type and allows all registered Panels to be accessed from it. 