### PR TITLE
Add filter for adding in customize menu item

### DIFF
--- a/ModularContent/Plugin.php
+++ b/ModularContent/Plugin.php
@@ -13,6 +13,7 @@ use ModularContent\Preview\Preview_Revision_Indicator;
  */
 class Plugin {
 
+	const TOOL_ARG        = 'tool';
 	const CONTENT_TOOL_ID = 'content';
 
 	/** @var self */
@@ -179,7 +180,7 @@ class Plugin {
 
 	private function get_content_url() {
 		$page_url = get_edit_post_link( get_the_ID() );
-		return sprintf( '%s&tool=%s', $page_url, self::CONTENT_TOOL_ID );
+		return add_query_arg( array( self::TOOL_ARG => self::CONTENT_TOOL_ID ), $page_url );
 	}
 
 	public function do_the_panels() {


### PR DESCRIPTION
Sam and Daniel, this is the update to hook into our Customize menu filter and add in the page for Panels.

Sam a couple of notes here: for this and the site builder items, I'm linking to the edit page for the given post and appending `&tool={tool-name}` to the URL. My assumption is that you can detect this on the client side and activate the correct overlay. Does this work for you? I'm open to changing that functionality or naming if you have a preference.

Also, do we have any objections to adding a filter into what eventually will become Panels 4.0 that won't get used on most projects (unless they happen to also implement this Customize bar)? Just wanted to throw that out there to make sure we're all on board.