### PR TITLE
Updating panel-wrapper.php to use get_nest_index()

### DIFF
--- a/public-views/panel-wrapper.php
+++ b/public-views/panel-wrapper.php
@@ -12,7 +12,9 @@
  * @var string $html The rendered HTML of the panel
  */
 
-$zebra = ( $index % 2 == 0 ) ? 'odd' : 'even';
+$panel_index = get_nest_index();
+
+$zebra = ( $panel_index % 2 == 0 ) ? 'odd' : 'even';
 ?>
 <div
 	class="panel panel-type-<?php esc_attr_e($panel->get('type')); ?> panel-<?php echo $zebra; ?>"


### PR DESCRIPTION
With the introduction of child panels, the `$index` global was no longer accurately returning the index of the parent panels.  So `get_nest_index()` is now being used to accurately assign the `.panel-odd` and `.panel-even` classes.