### PR TITLE
do not display panels in password protected posts

### DIFF
--- a/ModularContent/Plugin.php
+++ b/ModularContent/Plugin.php
@@ -81,6 +81,9 @@ class Plugin {
 			if ( $can_preview && ! empty( $_GET[ 'preview_panels' ] ) ) {
 				$this->loop = new Preview\Preview_Loop( $panels );
 			} else {
+				if ( post_password_required( $current_post ) ) {
+					$panels = null;
+				}
 				$this->loop = new Loop( $panels );
 			}
 		}


### PR DESCRIPTION
This solves a recurring problem we have on projects. If a post is password protected, the panels on that post should not display unless the content can also display. Panels should still display in the preview. And any loops outside the main loop will be unaffected.

'Tis a small change, so should be a quick review.