### PR TITLE
decode entities in post and term names before json output - #79584

### DIFF
--- a/ModularContent/AdminPreCache.php
+++ b/ModularContent/AdminPreCache.php
@@ -86,7 +86,7 @@ class AdminPreCache implements \JsonSerializable {
 			if ( empty( $excerpt ) ) {
 				$excerpt = $post->post_content;
 			}
-			$title = get_the_title( $post );
+			$title = html_entity_decode( get_the_title($post), ENT_QUOTES | ENT_HTML401 );
 			$excerpt = wp_trim_words( $excerpt, 40, '&hellip;' );
 			$excerpt = apply_filters( 'get_the_excerpt', $excerpt );
 			$thumbnail_html = get_the_post_thumbnail( $post->ID, array( 150, 150 ) );

--- a/ModularContent/Fields/Post_List.php
+++ b/ModularContent/Fields/Post_List.php
@@ -600,7 +600,7 @@ class Post_List extends Field {
 				$term_name = self::build_hierarchical_term_name( $term );
 				$options[] = [
 					'value' => $term->term_id,
-					'label' => $term_name,
+					'label' => html_entity_decode( $term_name, ENT_QUOTES | ENT_HTML401 ), // it will be re-encoded later
 				];
 			}
 			usort( $options, [ $this, 'sort_by_label' ] );

--- a/ModularContent/MetaBox.php
+++ b/ModularContent/MetaBox.php
@@ -430,7 +430,7 @@ class MetaBox {
 			foreach ( $posts as $post ) {
 				$response['posts'][] = array(
 					'value' => $post->ID,
-					'label' => esc_html(get_the_title($post)),
+					'label' => html_entity_decode( get_the_title($post), ENT_QUOTES | ENT_HTML401 ),
 				);
 			}
 


### PR DESCRIPTION
WP gives us post and terms names with some entities (e.g., ampersands)
encoded. When those strings are passed into the UI, the are
escaped again, yielding raw entity strings displaying to the
user. By decoding them on the server side, the client side
can continue to escape them, thereby re-encoding those entities.