### PR TITLE
expose the indexed name of a wysiwyg editor

### DIFF
--- a/ModularContent/Fields/TextArea.php
+++ b/ModularContent/Fields/TextArea.php
@@ -70,7 +70,7 @@ class TextArea extends Field {
 		return $data;
 	}
 
-	protected function get_indexed_name() {
+	public function get_indexed_name() {
 		$name = $this->esc_class( $this->name );
 		return $name . '-' . $this->index;
 	}


### PR DESCRIPTION
The ID is used as the editor ID when generating the settings
blueprint, and can be helpful for filtering the toolbar
buttons for tinymce. Example:

```
add_filter( 'mce_buttons', function( $buttons, $editor_id ) use ( $field ) {
	if ( $field->get_indexed_name() === $editor_id ) {
		$to_remove = [ 'bullist', 'numlist', 'wp_more', 'fullscreen' ];
		$buttons = array_diff( $buttons, $to_remove );
	}
	return $buttons;
}, 10, 2 );
```