### PR TITLE
do not copy page template meta

### DIFF
--- a/ModularContent/Meta_Copier.php
+++ b/ModularContent/Meta_Copier.php
@@ -57,13 +57,15 @@ class Meta_Copier {
 	 * the destination post.
 	 *
 	 * @param int $post_id
+	 *
 	 * @return array
 	 */
 	private function get_meta_key_blacklist( $post_id ) {
-		$list = array(
+		$list = [
 			'_edit_lock',
 			'_edit_last',
-		);
+			'_wp_page_template',
+		];
 
 		return apply_filters( 'modular_content_meta_copier_blacklist', $list, $post_id );
 	}


### PR DESCRIPTION
WordPress treats page template meta specially when updating
a post (including an autosave). When converting a WP_Post
to an array, WP will add the _wp_page_template meta as a
field named page_template. This happens in wp_update_post
when, for example, an autosave is updated. That value is
then passed to wp_insert_post, where it is specially
handled, updating the post meta to the selected template
(if it's valid for the post type), or resetting it to
the default template. For revisions/autosaves, no template
is valid, so it resets it to the default template. But
it then uses update_post_meta instead of update_metadata,
the former having the side effect of redirecting meta changes
for a revision/autosave to their parent post.

In summary: by saving the page template in the autosave
meta, WP will reset the live page's template to default.
We avoid that by not saving the page template for the
autosave.