### PR TITLE
Fix bug causing heartbeat_received filter data to return null

### DIFF
--- a/ModularContent/Preview/Preview_Revision_Indicator.php
+++ b/ModularContent/Preview/Preview_Revision_Indicator.php
@@ -24,7 +24,7 @@ class Preview_Revision_Indicator {
 		add_action( '_wp_put_post_revision', [ $this, 'copy_post_meta_to_autosaves' ], 10, 1 );
 		add_action( 'wp_creating_autosave', [ $this, 'track_updated_post_revisions' ], 10, 1 );
 
-        return $response;
+		return $response;
 	}
 
 	public function add_post_revision_to_heartbeat_response( $response, $data, $screen_id ) {


### PR DESCRIPTION
When panels filters into the heartbeat_received there is no return of the response array which breaks any data other plugins may have put into it before it got to this filter.  This commit adds the necessary returns to patch the bug.

I figured this out trying to track down why I wasn't getting takeover requests in gravity forms when other users wanted to edit a form I was editing.  Changing these lines fixed the bug.