### PR TITLE
Prevent post list field from setting transients on every page load

### DIFF
--- a/ModularContent/Fields/Post_List.php
+++ b/ModularContent/Fields/Post_List.php
@@ -411,7 +411,7 @@ class Post_List extends Field {
 	public static function get_posts_for_filters( $filters, $max = 10, $context = 0 ) {
 		$query = self::get_query_for_filters( $filters, $max, $context );
 		$cache = self::get_cache( $query );
-		if ( ! empty( $cache ) && $cache !== false ) {
+		if ( ! empty( $cache ) ) {
 			return $cache;
 		}
 


### PR DESCRIPTION
The Post List field caching was never actually returning any cached data and instead just setting transients on every page load that has this panel: http://p.tri.be/03ta0n