### PR TITLE
Add in fix for rel=noopener bug when saving panels on 5.1.1

### DIFF
--- a/ModularContent/Plugin.php
+++ b/ModularContent/Plugin.php
@@ -134,6 +134,9 @@ class Plugin {
 				add_action('add_meta_boxes_'.$post_type, array($this->metabox, 'register_meta_box'), 10, 0);
 			}
 		}
+
+		// Fix issue with post_content_filtered getting messed up by rel=noopener
+		remove_filter( 'content_filtered_save_pre', 'wp_targeted_link_rel' );
 	}
 
 	public function supported_post_types() {


### PR DESCRIPTION
Boise has confirmed that this resolves the issue; as promised, here it is in Panels proper.