### PR TITLE
Feature/ensure taxonomies exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,14 +77,11 @@ before_script:
   - export PATH=$PATH:/tmp/tools:vendor/bin
 
   # install Apache and WordPress setup scripts
-  - git clone https://github.com/lucatume/travis-apache-setup.git /tmp/tools/travis-apache-setup
+  - git clone https://github.com/defunctl/travis-apache-setup.git /tmp/tools/travis-apache-setup
   - chmod +x /tmp/tools/travis-apache-setup/apache-setup.sh
   - chmod +x /tmp/tools/travis-apache-setup/wp-install.sh
   - ln -s /tmp/tools/travis-apache-setup/apache-setup.sh /tmp/tools/apache-setup
   - ln -s /tmp/tools/travis-apache-setup/wp-install.sh /tmp/tools/wp-install
-
-  # install missing wp-cli/core-command
-  - composer global require wp-cli/core-command --no-interaction
 
   # download and install WordPress
   - wp-install --dir=/tmp/wordpress --dbname="$wpDbName" --dbuser="root" --dbpass="" --dbprefix=$wpDbPrefix --domain="$wpUrl" --title="Test" --admin_user=$wpAdminUsername --admin_password=$wpAdminPassword --admin_email=admin@wordpress.dev --theme=twentysixteen --empty

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,9 @@ before_script:
   - ln -s /tmp/tools/travis-apache-setup/apache-setup.sh /tmp/tools/apache-setup
   - ln -s /tmp/tools/travis-apache-setup/wp-install.sh /tmp/tools/wp-install
 
+  # install missing wp-cli/core-command
+  - composer global require wp-cli/core-command --no-interaction
+
   # download and install WordPress
   - wp-install --dir=/tmp/wordpress --dbname="$wpDbName" --dbuser="root" --dbpass="" --dbprefix=$wpDbPrefix --domain="$wpUrl" --title="Test" --admin_user=$wpAdminUsername --admin_password=$wpAdminPassword --admin_email=admin@wordpress.dev --theme=twentysixteen --empty
   - cd /tmp/wordpress

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
   - nvm use 6.9.4
 
   # Repo for Yarn
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
   - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,11 @@ before_script:
   # set up folders
   - mkdir -p $HOME/tools /tmp/wordpress
 
+  # install wp-cli
+  - wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -P /tmp/tools/
+  - chmod +x /tmp/tools/wp-cli.phar && mv /tmp/tools/wp-cli.phar /tmp/tools/wp
+  - export PATH=$PATH:/tmp/tools:vendor/bin
+
   # install Apache and WordPress setup scripts
   - git clone https://github.com/defunctl/travis-apache-setup.git /tmp/tools/travis-apache-setup
   - chmod +x /tmp/tools/travis-apache-setup/apache-setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ before_script:
   - export PATH=$PATH:/tmp/tools:vendor/bin
 
   # install Apache and WordPress setup scripts
-  - git clone https://github.com/defunctl/travis-apache-setup.git /tmp/tools/travis-apache-setup
+  - git clone https://github.com/lucatume/travis-apache-setup.git /tmp/tools/travis-apache-setup
   - chmod +x /tmp/tools/travis-apache-setup/apache-setup.sh
   - chmod +x /tmp/tools/travis-apache-setup/wp-install.sh
   - ln -s /tmp/tools/travis-apache-setup/apache-setup.sh /tmp/tools/apache-setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,11 +71,6 @@ before_script:
   # set up folders
   - mkdir -p $HOME/tools /tmp/wordpress
 
-  # install wp-cli
-  - wget https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -P /tmp/tools/
-  - chmod +x /tmp/tools/wp-cli.phar && mv /tmp/tools/wp-cli.phar /tmp/tools/wp
-  - export PATH=$PATH:/tmp/tools:vendor/bin
-
   # install Apache and WordPress setup scripts
   - git clone https://github.com/defunctl/travis-apache-setup.git /tmp/tools/travis-apache-setup
   - chmod +x /tmp/tools/travis-apache-setup/apache-setup.sh

--- a/ModularContent/Fields/Post_List.php
+++ b/ModularContent/Fields/Post_List.php
@@ -348,7 +348,9 @@ class Post_List extends Field {
 	}
 
 	public static function taxonomy_options() {
-		return apply_filters( 'modular_content_posts_field_taxonomy_options', [ 'post_tag' ] );
+		$taxonomies = apply_filters( 'modular_content_posts_field_taxonomy_options', [ 'post_tag' ] );
+
+		return array_values( array_filter( $taxonomies, 'taxonomy_exists' ) );
 	}
 
 	public static function p2p_options() {

--- a/tests/codeception/integration/Fields/Post_List_Test.php
+++ b/tests/codeception/integration/Fields/Post_List_Test.php
@@ -156,4 +156,20 @@ class Post_List_Test extends WPTestCase {
 		$this->assertNotEmpty( $images[ $attachment_id ][ $size ] );
 		$this->assertNotEmpty( $images[ $another_attachment_id ][ $size ] );
 	}
+
+	public function test_valid_taxonomies() {
+
+		register_taxonomy( 'valid', 'post' );
+
+		add_filter( 'modular_content_posts_field_taxonomy_options', function( $taxonomies ) {
+			return [
+				'post_tag',
+				'invalid',
+				'valid',
+				'category',
+			];
+		} );
+
+		$this->assertEquals( [ 'post_tag', 'valid', 'category' ], Post_List::taxonomy_options() );
+	}
 }


### PR DESCRIPTION
Ran into this issue on a project which was difficult to debug. Essentially, we were passing  `tribe_events_cat` in the Panels Service Provider, but the plugin wasn't active on all subsites on a multisite install and Panels expects these taxonomies/terms to exist.

Edit: Switched travis up to use a more reliable method/key server for yarn and submitted a now merged PR to https://github.com/lucatume/travis-apache-setup to include the proper wp-cli bundle and updated some outdated commands. 