### PR TITLE
Fix warnings being thrown by post picker fields

### DIFF
--- a/ModularContent/Fields/Post_List.php
+++ b/ModularContent/Fields/Post_List.php
@@ -116,9 +116,7 @@ class Post_List extends Field {
 	}
 
 	public function get_vars( $data, $panel ) {
-		if ( empty( $data ) ) {
-			$data = $this->default;
-		}
+		$data = wp_parse_args( $data, $this->default );
 		$posts = [ ];
 		if ( $data[ 'type' ] === 'manual' ) {
 			foreach ( $data[ 'posts' ] as $post_data ) {

--- a/ModularContent/Fields/Posts.php
+++ b/ModularContent/Fields/Posts.php
@@ -7,7 +7,7 @@ use ModularContent\Panel, ModularContent\AdminPreCache;
  * Class Posts
  *
  * @package ModularContent\Fields
- * 
+ *
  * This field type has been deprecated. Code should be updated
  * to use the Post_List field.
  *
@@ -28,7 +28,12 @@ class Posts extends Post_List {
 	protected $max = 12;
 	protected $min = 0;
 	protected $suggested = 0;
-	protected $default = '{ type: "manual", post_ids: [], filters: {}, max: 0 }';
+	protected $default = [
+		'type' => 'manual',
+		'post_ids' => [],
+		'filters' => [],
+		'max' => 0,
+	];
 	protected $show_max_control = false;
 
 	/**


### PR DESCRIPTION
Live Preview was breaking on multiple sites; @ChrisFlannagan tracked it down to being related to Whoops throwing a warning for a couple bugs. This PR fixes those couple of bugs, allowing Live Preview to work with Whoops enabled.