### PR TITLE
Fix search XSS

### DIFF
--- a/ModularContent/SearchFilter.php
+++ b/ModularContent/SearchFilter.php
@@ -34,8 +34,8 @@ class SearchFilter {
 		if ( $query->get( 'panel_search_filter' ) ) {
 			global $wpdb;
 			remove_filter( 'posts_search', array( $this, 'add_post_content_filtered_to_search_sql' ), 1000, 2 );
-			
-			$pattern = "#OR \($wpdb->posts.post_content LIKE '(.*?)'\)#";
+
+			$pattern = "#OR \($wpdb->posts.post_content LIKE '{(.*?)}'\)#";
 			$sql = preg_replace_callback( $pattern, array( $this, 'replace_callback' ), $sql );
 		}
 		return $sql;


### PR DESCRIPTION
Pretty serious XSS after WordPress changed the way LIKE queries work a while back. Tested a few sites with panels enabled and using the default WordPress search.

https://site.com/?s=test('hi')

```
WordPress database error: [You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '\'hi\')%'))) AND wp_posts.post_type IN ('post', 'page', 'attachment') AND (wp_p' at line 1]
SELECT SQL_CALC_FOUND_ROWS wp_posts.ID FROM wp_posts WHERE 1=1 AND (((wp_posts.post_title LIKE '%test(\'hi\')%') OR (wp_posts.post_excerpt LIKE '%test(\'hi\')%') OR (wp_posts.post_content LIKE '%test(\'hi\') OR (wp_posts.post_content_filtered LIKE '%test(\'hi\')%'))) AND wp_posts.post_type IN ('post', 'page', 'attachment') AND (wp_posts.post_status = 'publish' OR wp_posts.post_status = 'acf-disabled' OR wp_posts.post_author = 35 AND wp_posts.post_status = 'private') ORDER BY wp_posts.post_title LIKE '%test(\'hi\')%' DESC, wp_posts.post_date DESC LIMIT 0, 9
```