### PR TITLE
cache taxonomy term lists for 10 minutes

### DIFF
--- a/ModularContent/Fields/Post_List.php
+++ b/ModularContent/Fields/Post_List.php
@@ -2,7 +2,7 @@
 
 namespace ModularContent\Fields;
 
-use ModularContent\Panel, ModularContent\AdminPreCache;
+use ModularContent\AdminPreCache;
 use ModularContent\Util;
 
 /**
@@ -620,6 +620,11 @@ class Post_List extends Field {
 		$blueprint[ 'taxonomies' ] = [ ];
 
 		foreach ( $this->taxonomy_options() as $taxonomy_name ) {
+			$cached = get_transient( 'panelbpterms-' . $taxonomy_name );
+			if ( is_array( $cached ) ) {
+				$blueprint['taxonomies'][ $taxonomy_name ] = $cached;
+				continue;
+			}
 			$terms = get_terms( [
 				'taxonomy'        => $taxonomy_name,
 				'hide_empty'      => false,
@@ -640,6 +645,7 @@ class Post_List extends Field {
 			$labels = array_column( $options, 'label' );
 			array_multisort( $labels, SORT_ASC, $options );
 
+			set_transient( 'panelbpterms-' . $taxonomy_name, $options, 10 * MINUTE_IN_SECONDS );
 			$blueprint['taxonomies'][ $taxonomy_name ] = $options;
 		}
 


### PR DESCRIPTION
@defunctl optimized the term sorting in #183, but I'm finding that it's still a major bottleneck. We end up loading the exact same set of terms many times on every page load. This is a bandaid solution to cache those terms in a transient for 10 minutes. This cut about 70% off of admin page load times for a project with many Post_List fields.