### PR TITLE
Fixed a deprecation issue with oembed class usage from WP.

### DIFF
--- a/ModularContent/Fields/Video.php
+++ b/ModularContent/Fields/Video.php
@@ -2,8 +2,7 @@
 
 
 namespace ModularContent\Fields;
-use ModularContent\OEmbedder;
-use ModularContent\Panel;
+use WP_oEmbed;
 
 /**
  * Class Video
@@ -32,7 +31,7 @@ class Video extends Text {
 	 * @return object
 	 */
 	public static function get_data( $url, $args = array() ) {
-		$oembed = new OEmbedder( $url, $args );
-		return $oembed->get_oembed_data();
+		$oembed = new WP_oEmbed();
+		return $oembed->get_html( $url, $args );
 	}
 }


### PR DESCRIPTION
There is a warning thrown for WP version 5.3 forward when using the Video panel:

> **Deprecated**: class-oembed.php is deprecated since version 5.3.0! Use wp-includes/class-wp-oembed.php instead. in /var/www/html/wp/wp-includes/functions.php on line 4903

This is a fix for that.

